### PR TITLE
Fixed file name in documentation to add smelte in an existing project

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add exported css file to `public/index.html`:
 <link rel='stylesheet' href='/utils.css'>
 ```
 
-Create `smelte.css` in `src` folder with this line:
+Create `tailwind.css` in `src` folder with this line:
 ```
 @import 'smelte/src/tailwind';
 ```


### PR DESCRIPTION
There is no file named `smelte.css`. We nee to import `tailwind.css` that we just created in the step above it