### PR TITLE
Add dynamic prop duration and delay for Dialog

### DIFF
--- a/src/components/Dialog/Dialog.svelte
+++ b/src/components/Dialog/Dialog.svelte
@@ -11,8 +11,10 @@
   export let titleClasses = "text-lg font-bold pb-4";
   export let actionsClasses = "flex w-full justify-end pt-4";
   export let opacity = 0.5;
+  export let duration = 150;
+  export let delay = 150;
 
-  const transitionProps = { duration: 150, easing: quadIn, delay: 150 };
+  const transitionProps = { duration, easing: quadIn, delay };
 </script>
 
 {#if value}


### PR DESCRIPTION
Add dynamic prop duration and delay for Dialog. This could be useful for some specific cases when you dont want to have a delay and want to have a longer duration for the transition.
```
<Dialog bind:value={showDialog} duration={1000} delay={0}>
...
</Dialog>
```