### PR TITLE
Fix color prop missing for icon, add not selected color for tabs

### DIFF
--- a/src/components/Icon/Icon.svelte
+++ b/src/components/Icon/Icon.svelte
@@ -5,6 +5,7 @@
   export let xs = false;
   export let reverse = false;
   export let tip = false;
+  export let color = "";
 </script>
 
 <style>
@@ -23,6 +24,7 @@
   class:reverse
   class:tip
   class:text-base={small}
-  class:text-xs={xs}>
+  class:text-xs={xs}
+  style="color: {color}">
   <slot />
 </i>

--- a/src/components/Tabs/TabButton.svelte
+++ b/src/components/Tabs/TabButton.svelte
@@ -9,7 +9,7 @@
   export let to = "";
   export let selected = "";
   export let color = "primary";
-  export let notselectedcolor = "white";
+  export let notSelectedColor = "white";
 
   let className = "";
   export {className as class};
@@ -22,7 +22,7 @@
 
   const { txt } = utils(color);
 
-  $: textColor = selected === id ? txt() : "text-" + notselectedcolor;
+  $: textColor = selected === id ? txt() : "text-" + notSelectedColor;
 </script>
 
 {#if to}

--- a/src/components/Tabs/TabButton.svelte
+++ b/src/components/Tabs/TabButton.svelte
@@ -9,6 +9,7 @@
   export let to = "";
   export let selected = "";
   export let color = "primary";
+  export let notselectedcolor = "white";
 
   let className = "";
   export {className as class};
@@ -21,7 +22,7 @@
 
   const { txt } = utils(color);
 
-  $: textColor = selected === id ? txt() : "text-white";
+  $: textColor = selected === id ? txt() : "text-" + notselectedcolor;
 </script>
 
 {#if to}

--- a/src/components/Tabs/Tabs.svelte
+++ b/src/components/Tabs/Tabs.svelte
@@ -11,7 +11,7 @@
   export let items = [];
   export let indicator = true;
   export let color = "white";
-  export let notselectedcolor = "white";
+  export let notSelectedColor = "white";
   let className = "";
   export {className as class};
   export let loading = false;
@@ -51,7 +51,7 @@
   bind:this={node}>
   {#each items as item, i}
     <slot name="item" {color} {item}>
-      <Tab bind:selected {...item} {color} {notselectedcolor}>{item.text}</Tab>
+      <Tab bind:selected {...item} {color} {notSelectedColor}>{item.text}</Tab>
     </slot>
   {/each}
   {#if indicator}

--- a/src/components/Tabs/Tabs.svelte
+++ b/src/components/Tabs/Tabs.svelte
@@ -11,6 +11,7 @@
   export let items = [];
   export let indicator = true;
   export let color = "white";
+  export let notselectedcolor = "white";
   let className = "";
   export {className as class};
   export let loading = false;
@@ -50,7 +51,7 @@
   bind:this={node}>
   {#each items as item, i}
     <slot name="item" {color} {item}>
-      <Tab bind:selected {...item} {color}>{item.text}</Tab>
+      <Tab bind:selected {...item} {color} {notselectedcolor}>{item.text}</Tab>
     </slot>
   {/each}
   {#if indicator}


### PR DESCRIPTION
Issue: Missing color property for icon.
![icon_problem](https://user-images.githubusercontent.com/25986436/66113917-69a9ab80-e5d6-11e9-862c-3791259290dd.png)

Suggestion: Add property `notselectedcolor`. Use case: if the tabs background is white, the tabs that are not selected will also have white text (it is hardcoded) and you cannot see the text. Would be nice if there was a `notselectedcolor` property for the tabs so you can customize the text color when a tab is not selected.

I have added a pull request for these two things! Have a nice day!
  