### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/components/Card/Title.svelte
+++ b/src/components/Card/Title.svelte
@@ -1,7 +1,7 @@
 <script>
   let className = "";
   export {className as class};
-  export let hover = true;
+  export const hover = true;
   export let title = "";
   export let subheader = "";
   export let avatar = "";

--- a/src/components/List/List.svelte
+++ b/src/components/List/List.svelte
@@ -2,12 +2,12 @@
   import ListItem from "./ListItem.svelte";
 
   export let items = [];
-  export let item = {};
+  export const item = {};
   export let value = "";
-  export let text = "";
+  export const text = "";
   export let dense = false;
   export let navigation = false;
-  export let level = null;
+  export const level = null;
   export let select = false;
   let className = "";
   export {className as class};

--- a/src/components/List/ListItem.svelte
+++ b/src/components/List/ListItem.svelte
@@ -11,12 +11,12 @@
   export let disabled = false;
   export let dense = false;
   export let navigation = false;
-  export let to = "";
+  export const to = "";
   export let selected = false;
   export let tabindex = null;
-  export let item = null;
-  export let items = [];
-  export let level = null;
+  export const item = null;
+  export const items = [];
+  export const level = null;
   export let basicClasses = "hover:bg-gray-transDark relative overflow-hidden transition p-4 cursor-pointer text-gray-700 flex items-center z-10";
   export let itemClasses = "";
   export let selectedClasses = "bg-gray-200 hover:bg-primary-transDark";

--- a/src/components/RadioButton/RadioButton.svelte
+++ b/src/components/RadioButton/RadioButton.svelte
@@ -6,7 +6,7 @@
   export let label = "";
   export let color = "primary";
   export let disabled = false;
-  export let name = "";
+  export const name = "";
   export let value = "";
   export let wrapperClasses = "inline-flex block items-center mb-2 cursor-pointer z-0";
 

--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -9,7 +9,7 @@
   let className = "";
   export {className as class};
   export let value = "";
-  export let text = "";
+  export const text = "";
   export let label = "";
   export let selectedLabel = "";
   export let color = "primary";

--- a/src/components/Slider/Slider.svelte
+++ b/src/components/Slider/Slider.svelte
@@ -3,7 +3,7 @@
 
   export let value = 0;
   export let label = "";
-  export let color = "primary";
+  export const color = "primary";
   export let disabled = false;
   export let min = 0;
   export let max = 100;

--- a/src/components/Treeview/Treeview.svelte
+++ b/src/components/Treeview/Treeview.svelte
@@ -6,11 +6,11 @@
   import { slide } from "svelte/transition";
 
   export let items = [];
-  export let value = "";
-  export let text = "";
-  export let dense = false;
-  export let navigation = false;
-  export let select = false;
+  export const value = "";
+  export const text = "";
+  export const dense = false;
+  export const navigation = false;
+  export const select = false;
   export let level = 0;
   export let showExpandIcon = true;
   export let expandIcon = "arrow_right";
@@ -19,7 +19,7 @@
   export let listClasses = "rounded";
   export let selectedClasses = "bg-primary-trans";
 
-  let className = "";
+  const className = "";
   export {className as class};
 
   let expanded = [];


### PR DESCRIPTION
I have updated svelte to the latest version ```3.16.7``` and I get some annoying compiler warnings ```unused export property 'PROPERTY_NAME'. If it is for external reference only, please consider using `export const 'PROPERTY_NAME'```.
I changed those properties from ```let``` to ```const``` to get rid of the warnings.
