### PR TITLE
When clicking the text field for a non-autocomplete Select, close the list

### DIFF
--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -89,7 +89,7 @@
   }
 
   function handleInputClick() {
-    if(autocomplete) {
+    if (autocomplete) {
       showList = true;
     } else {
       showList = !showList;
@@ -104,7 +104,7 @@
     .add(classes, true, classesDefault)
     .add(className)
     .get();
-  
+
   const ocb = new ClassBuilder(optionsClasses, optionsClassesDefault);
   $: o = ocb
     .flush()

--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -88,6 +88,14 @@
     );
   }
 
+  function handleInputClick() {
+    if(autocomplete) {
+      showList = true;
+    } else {
+      showList = !showList;
+    }
+  }
+
   const onHideListPanel = () => showList = false;
 
   const cb = new ClassBuilder(classes, classesDefault);
@@ -119,7 +127,7 @@
       {labelClasses}
       {inputClasses}
       {prependClasses}
-      on:click={e => (showList = true)}
+      on:click={handleInputClick}
       on:click-append={(e => showList = !showList)}
       on:click
       on:input={filterItems}

--- a/src/components/TextField/TextField.svelte
+++ b/src/components/TextField/TextField.svelte
@@ -179,7 +179,7 @@
   {:else if select && !autocomplete}
     <input
       readonly
-      class="{iClasses}"
+      class="cursor-pointer {iClasses}"
       on:change
       on:input
       {disabled}
@@ -226,7 +226,7 @@
     {outlined}
     {focused}
     {error} />
-  
+
   {#if showHint}
     <Hint
       {hint}

--- a/src/components/TextField/TextField.svelte
+++ b/src/components/TextField/TextField.svelte
@@ -61,7 +61,6 @@
   export let extend = () => {};
 
   export let focused = false;
-  let iClasses = i => i;
   let wClasses = i => i;
   let aClasses = i => i;
   let pClasses = i => i;
@@ -90,11 +89,12 @@
       .add(add)
       .remove('bg-gray-100', disabled)
       .add('bg-gray-50', disabled)
+      .add('cursor-pointer', select && !autocomplete)
       .remove(remove)
       .replace(replace)
       .extend(extend)
       .get();
-    
+
   $: wClasses = ccb.flush()
       .add('select', select || autocomplete)
       .add('dense', dense)
@@ -179,7 +179,7 @@
   {:else if select && !autocomplete}
     <input
       readonly
-      class="cursor-pointer {iClasses}"
+      class="{iClasses}"
       on:change
       on:input
       {disabled}


### PR DESCRIPTION
This also sets `cursor-pointer` on the text field when autocomplete is disabled, so that it applies to the entire Select control.