### PR TITLE
Sidenav cant be opened after leaving navigation drawers demo

### DIFF
--- a/src/routes/components/_layout.svelte
+++ b/src/routes/components/_layout.svelte
@@ -1,6 +1,8 @@
 <script>
+  import { showNav } from "stores.js";
   export let segment = "";
 
+  showNav.set(true);
   $: n = (segment || "").replace(new RegExp('-', 'g'), ' ');
   $: name = n.length ? n.charAt(0).toUpperCase() + n.slice(1) : "";
 


### PR DESCRIPTION
Thanks for the great library! I'll be sure to use it in my next project.

I hid the navigation drawer from the demo.
After navigating to another page, there is no way to toggle the component menu back open without refreshing the page.

Let me know there is a preferred fix other than what I've got here - I'm brand new to Svelte :)