### PR TITLE
upd(Select): removed simultaneous use of attribute and shorthand

### DIFF
--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -21,7 +21,7 @@
   export let placeholder = "";
   export let hint = "";
   export let error = false;
-  export let append = "";
+  export let append = "arrow_drop_down";
   export let dense = false;
   export let persistentHint = false;
   export let autocomplete = false;
@@ -128,7 +128,6 @@
       on:click-append={(e => showList = !showList)}
       on:click
       on:input={filterItems}
-      append="arrow_drop_down"
       appendReverse={showList}
     />
   </slot>


### PR DESCRIPTION
Hello! I have found that after upgrading svelte(3.18.1 -> 3.19.1) my project is failing build
![image](https://user-images.githubusercontent.com/10661578/75363023-3982e200-58c2-11ea-91b4-43cd74b376dd.png)
I have found, that from now on svelte disallows simultaneous use of attributes and shorthands.
https://github.com/sveltejs/svelte/commit/507661325629ca2b79df9d0103e47d5bd316f8e2
This pull request fixes it