### PR TITLE
Update Select when `items` changes after creation

### DIFF
--- a/src/components/Select/Select.svelte
+++ b/src/components/Select/Select.svelte
@@ -46,7 +46,6 @@
   let className = "";
   export {className as class};
 
-  let filteredItems = items;
   let itemsProcessed = [];
 
 
@@ -68,10 +67,13 @@
     return value !== undefined ? (itemsProcessed.find(i => i.value === value) || { text: "" }).text : "";
   }
 
+  let filterText = null;
+  $: filteredItems = itemsProcessed.filter(
+    i => !filterText || i.text.toLowerCase().includes(filterText)
+  );
+
   function filterItems({ target }) {
-    filteredItems = itemsProcessed.filter(i =>
-      i.text.toLowerCase().includes(target.value.toLowerCase())
-    );
+    filterText = target.value.toLowerCase();
   }
 
   function handleInputClick() {


### PR DESCRIPTION
Updating `items` after creating the Select didn't work because `filteredItems` wasn't reactive to changes in `itemsProcessed`. This fixes that while retaining the filter ability.