### PR TITLE
Fix AppBar width

### DIFF
--- a/src/components/AppBar/AppBar.svelte
+++ b/src/components/AppBar/AppBar.svelte
@@ -2,9 +2,10 @@
   import { ClassBuilder } from "../../utils/classes.js";
 
   let className = "";
-  export {className as class};
+  export { className as class };
 
-  let classesDefault = "fixed top-0 w-screen items-center flex-wrap flex left-0 z-30 p-0 h-16 elevation-3 bg-primary-300 dark:bg-dark-600";
+  let classesDefault =
+    "fixed top-0 w-full items-center flex-wrap flex left-0 z-30 p-0 h-16 elevation-3 bg-primary-300 dark:bg-dark-600";
 
   export let classes = classesDefault;
 


### PR DESCRIPTION
AppBar on docs site was butting against right side of the window due to `w-screen` with `fixed` position. 

<img width="227" alt="Screen Shot 2020-05-24 at 2 10 18 PM" src="https://user-images.githubusercontent.com/14936212/82761428-79c20580-9dc8-11ea-8df6-37cc3eca7687.png">

Updated to use `w-full` to display header as intended.

<img width="173" alt="Screen Shot 2020-05-24 at 2 11 08 PM" src="https://user-images.githubusercontent.com/14936212/82761431-7fb7e680-9dc8-11ea-8c16-91551bd5926e.png">
