### PR TITLE
Update NavigationDrawer.svelte

### DIFF
--- a/src/components/NavigationDrawer/NavigationDrawer.svelte
+++ b/src/components/NavigationDrawer/NavigationDrawer.svelte
@@ -63,7 +63,7 @@
   }
 
   aside {
-    height: calc(100vh - 4rem);
+    height: 100vh;
   }
 </style>
   


### PR DESCRIPTION
remove the hard-coded -4rem that caused not 100% height on mobile view. #118 