### PR TITLE
allow setting delay timing for show/hide tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.svelte
+++ b/src/components/Tooltip/Tooltip.svelte
@@ -10,6 +10,8 @@
   export let show = false;
 
   export let timeout = null;
+  export let delayHide = 100;
+  export let delayShow = 100;
 
   const cb = new ClassBuilder(classes, classesDefault);
   $: c = cb
@@ -63,8 +65,8 @@
 
 <div class="relative inline-block">
   <div
-    on:mouseenter={debounce(showTooltip, 100)}
-    on:mouseleave={debounce(hideTooltip, 500)}
+    on:mouseenter={debounce(showTooltip, delayShow)}
+    on:mouseleave={debounce(hideTooltip, delayHide)}
     on:mouseenter
     on:mouseleave
     on:mouseover


### PR DESCRIPTION
current hard coded delay of 500ms for the hideTootip is not making sense especially when multiple icons on appbar is having tooltip, this will lead to ugly multiple tootip showing up at appbar because user mouse move over a few icons in a row.

new changes export delayShow and delayHide and default it at 100ms, 100ms is pretty good. other devs might want to change to less than 100.