### PR TITLE
Trigger ripple on mousedown instead of click (mouseup)

### DIFF
--- a/src/components/Ripple/ripple.js
+++ b/src/components/Ripple/ripple.js
@@ -37,10 +37,11 @@ function ripple(color, centered) {
 
 export default function r(color = "primary", centered = false) {
   return function(node) {
-    node.addEventListener("click", ripple(color, centered));
+    const onMouseDown = ripple(color, centered);
+    node.addEventListener("mousedown", onMouseDown);
 
     return {
-      onDestroy: () => node.removeEventListener("click")
+      onDestroy: () => node.removeEventListener("mousedown", onMouseDown),
     };
   };
 }


### PR DESCRIPTION
Based on other reference implementations (and general feel), the ripple should be triggered on `mousedown` and not `click` (~`mouseup`).

- Material Design Components
  - https://material.io/develop/web/components/ripples
  - https://material-components.github.io/material-components-web-catalog/#/component/ripple
- Material-UI (React)
  - https://material-ui.com/components/buttons/#button
- svelte-mui
  - https://svelte-mui.ibbf.ru/button
  - https://svelte-mui.ibbf.ru/ripple
  - https://github.com/vikignt/svelte-mui/blob/master/src/Ripple.svelte
- Angular Material
  - https://material.angular.io/components/ripple/examples

`svelte-mui` also only triggers on [left click](https://github.com/vikignt/svelte-mui/blob/master/src/Ripple.svelte#L122-L127), but it seemed to be unique compared to the other implementations.  We may still need to add a [touchstart](https://github.com/vikignt/svelte-mui/blob/master/src/Ripple.svelte#L129-L135).  Since smelte cleanups up the ripple with the `animationend` event, I think this is cleaner than trying to do so with `mouseup` / `touchend` / `dragend` / etc.

Side note: It would be nice to show the [Ripple](https://github.com/matyunya/smelte/blob/master/src/components/Ripple/Ripple.svelte) component as well as `use:ripple` action. 