### PR TITLE
fix Safari's Square Ripple Bug

### DIFF
--- a/src/components/Button/Button.svelte
+++ b/src/components/Button/Button.svelte
@@ -24,7 +24,7 @@
   export let add = "";
   export let replace = {};
 
-  const classesDefault = 'py-2 px-4 uppercase text-sm font-medium relative overflow-hidden';
+  const classesDefault = 'z-10 py-2 px-4 uppercase text-sm font-medium relative overflow-hidden';
   const basicDefault = 'text-white transition';
   const outlinedDefault = 'bg-transparent border border-solid';
   const textDefault = 'bg-transparent border-none px-4 hover:bg-transparent';


### PR DESCRIPTION
if not adding the "z-10", Safari browser round button will have a "square ripple" showing infront of the button.
adding the "z-10" to the parent container of the Button will force the "ripple" show below the Round button and eventually a correct ripple effect inside a round button.