### PR TITLE
Fix production build

### DIFF
--- a/src/components/Button/variants.js
+++ b/src/components/Button/variants.js
@@ -6,14 +6,19 @@ module.exports = {
     `bg-${color}-50`,
     `bg-${color}`,
     `text-${color}`,
-    `text-${color}-500`
+    `text-${color}-500`,
+    `hover:bg-${color}-trans`,
+    `hover:bg-${color}-trans`,
+    `dark-hover:bg-${color}-transDark`,
+    `hover:bg-${color}-transLight`,
   ],
   normal: color => [
     `text-${color}-500`,
     `text-${color}-400`,
     `bg-${color}-500`,
     `bg-${color}-400`,
-    `border-${color}-400`
+    `border-${color}-400`,
+    `hover:bg-${color}-400`,
   ],
   light: color => [
     `text-${color}-400`,

--- a/src/utils/css-extractor.js
+++ b/src/utils/css-extractor.js
@@ -44,7 +44,7 @@ function getComponentCodes(name) {
   return flatten(root.map(v => {
     const dir = fs.readdirSync(v);
     return dir
-      .filter(w => fs.readdirSync(path.join(v,w)).includes(name + ".svelte"))
+      .filter(w => fs.readdirSync(path.join(v, w)).includes(name + ".svelte"))
       .map(w => path.join(v, w, name + ".svelte"));
   }));
 }
@@ -71,7 +71,7 @@ const whitelist = [
   // /ripple/
   "ripple", "ripple-normal", "ripple-centered",
   // /w\-.\/7/
-  ...flatten(["xl\:w","lg\:w","md\:w","sm\:w","w"].map(v=>[1,2,3,4,5,6].map(w=>v+"-"+w+"\/7")))
+  ...flatten(["xl\:w", "lg\:w", "md\:w", "sm\:w", "w"].map(v => [1, 2, 3, 4, 5, 6].map(w => v + "-" + w + "\/7")))
 
 ]
 module.exports = function extractor(content, ownColors = ["primary", "white", "gray"]) {
@@ -117,9 +117,12 @@ module.exports = function extractor(content, ownColors = ["primary", "white", "g
   const recursiveCrawl = [...usedComponents].map(
     v => {
       const cont = getComponentCodes(v);
-      console.log(cont);
-
-      return cont.map(w=>extractor(fs.readFileSync(w,{encoding:"utf-8"}), usedColors[v]));
+      return cont.map(
+        w => extractor(
+          fs.readFileSync(w, { encoding: "utf-8" }),
+          usedColors[v]
+        )
+      );
     }
   )
   return [

--- a/src/utils/css-extractor.js
+++ b/src/utils/css-extractor.js
@@ -110,6 +110,10 @@ module.exports = function extractor(content, ownColors = ["primary", "white", "g
   const fromClasses = content.match(/class:[A-Za-z0-9-_]+/g) || [];
   const defaultComponentClasses =
     content.match(/lasses = ("[a-zA-Z0-9-_ ]+")/g) || [];
+
+  // TODO: Each used component is crawled once per .svelte file.
+  // Could improve performance by globally tracking which component/colors are
+  // already checked
   const recursiveCrawl = [...usedComponents].map(
     v => {
       const cont = getComponentCodes(v);

--- a/src/utils/css-extractor.js
+++ b/src/utils/css-extractor.js
@@ -65,6 +65,11 @@ module.exports = function extractor(content) {
 
       if (node.type === "InlineComponent") {
         usedComponents.add(node.name);
+
+        // catch default colors
+        if (!usedColors[node.name]) {
+          usedColors[node.name] = new Set(ownColors);
+        }
       }
 
       if (color && color[0].data) {


### PR DESCRIPTION
Hi, three parts here:
- recursive crawl: Add the code of used smelte components to the purgeCss extractor. If the build performance is bad, there might be ways to improve it, since there are a bit too many recursions. I left a note in the code.
- add hardcoded whitelist. I tried several things, eg. updating the @fullhuman/postcss-purgecss to newer version 2.3.0, but nothing seemed to make whitelisting work. So, I've put the classes in the extractor. It is workaround, rather than  a fix. 
- update button hover variants. The hover:... classes were purged away, so I've explicitly added them for button. I did not check other components, they may have the same problem.


Should fix: #115, #110, #97, #91 
Could fix: #155 
