### PR TITLE
Using CSS vars for getting color

### DIFF
--- a/src/components/Slider/Slider.svelte
+++ b/src/components/Slider/Slider.svelte
@@ -24,7 +24,7 @@
     .add($$props.class)
     .get();
 
-  const getColor = c => getComputedStyle(document.documentElement).getPropertyValue(c);
+  const getColor = c => `var(${c})`
 
   let style;
   $: {


### PR DESCRIPTION
getComputeStyle is not existent at server-side and that causes the HTTP 500 error. Using CSS var fixes the error.

By the way, thanks for smelte, it's really cool !!