### PR TITLE
Minor examples syntax error fixes

### DIFF
--- a/examples/buttons.txt
+++ b/examples/buttons.txt
@@ -1,6 +1,8 @@
 <script>
-  import Button from "smelte/src/components/Button";
-  import Icon from "smelte/src/components/Icon";
+  import {
+    Button,
+    Icon
+  } from "smelte";
 </script>
 
 <h6 class="mb-3 mt-6">Basic</h6>

--- a/examples/card.txt
+++ b/examples/card.txt
@@ -3,7 +3,7 @@
 		Card,
 		Button,
 		Image
-	} from 'smelte';
+	} from "smelte";
 </script>
 
 <Card.Card>

--- a/examples/checkboxes.txt
+++ b/examples/checkboxes.txt
@@ -1,10 +1,9 @@
 <script>
-  import { 
+  import {
     Checkbox,
-    RadioButton,
-    Switch,
-    Icon,
-   } from "smelte";
+    RadioButtonGroup,
+    Switch
+  } from "smelte";
 </script>
 
 <h5 class="pb-8 pt-10" id="checkboxes">Checkboxes</h5>
@@ -15,16 +14,16 @@
 
 <h5 class="pb-8 pt-10" id="radio-buttons">Radio buttons</h5>
 
-<RadioButton
+<RadioButtonGroup
   name="test"
   items={[{ value: 1, label: 'One' }, { value: 2, label: 'Two' }]} />
 
-<RadioButton
+<RadioButtonGroup
   name="Colored test"
   color="blue"
   items={[{ value: 1, label: 'One' }, { value: 2, label: 'Two' }]} />
 
-<RadioButton
+<RadioButtonGroup
   name="test-disabled"
   disabled
   items={[{ value: 1, label: 'One' }, { value: 2, label: 'Two' }]} />

--- a/examples/chip-outlined.txt
+++ b/examples/chip-outlined.txt
@@ -1,5 +1,5 @@
 <script>
-  import Chip from 'smelte/src/components/Chip';
+  import { Chip } from "smelte";
 
   let closed = false;
   let clicked = false;

--- a/examples/chip.txt
+++ b/examples/chip.txt
@@ -1,5 +1,5 @@
 <script>
-  import Chip from 'smelte/src/components/Chip';
+  import { Chip } from "smelte";
 
   let closed = false;
   let clicked = false;

--- a/examples/custom-lists.txt
+++ b/examples/custom-lists.txt
@@ -1,18 +1,22 @@
 <script>
-	const menu = [
+  import { List } from "smelte";
+
+  const menu = [
 		{ to: "/components/text-fields", text: 'Text fields' },
 		{ to: "/components/buttons", text: 'Buttons' },
 		{ to: "/components/selection-controls#checkboxes", text: 'Checkboxes' },
 		{ to: "/components/selection-controls#radio-buttons", text: 'Radio buttons' },
 		{ to: "/components/selection-controls#switches", text: 'Switches' },
 		{ to: "/components/lists", text: 'Lists' },
-	];
+  ];
+
+  let selected;
+
 </script>
 
 <List bind:value={selected} items={menu} dense navigation>
 	<li slot="item" let:item={item}>
 		<div
-			use:ripple
 			class="cursor-pointer p-4 border-alert-50 border my-2 border-solid" 
 			on:click={() => selected = item.text}
 			class:bg-alert-50={selected === item.text}

--- a/examples/date-pickers.txt
+++ b/examples/date-pickers.txt
@@ -1,7 +1,9 @@
 <script>
-  import DatePicker from "smelte/src/components/DatePicker";
+  import { DatePicker } from "smelte";
   let selected;
 </script>
 
+<div>
 <small>I selected {selected ? selected.toLocaleDateString() : "nothing"}</small>
-<DatePicker on:change={i => selected = i } />
+</div>
+<DatePicker on:change={i => selected = i.detail } />

--- a/examples/dialog.txt
+++ b/examples/dialog.txt
@@ -1,6 +1,8 @@
 <script>
-	import Dialog from 'smelte/src/components/Dialog';
-	import Button from 'smelte/src/components/Button';
+  import {
+    Dialog,
+    Button
+  } from "smelte";
   
   let showDialog = false;
 </script>

--- a/examples/images.txt
+++ b/examples/images.txt
@@ -1,5 +1,5 @@
 <script>
-  import Image from 'smelte/src/components/Image';
+  import { Image } from "smelte";
 
   const range = [...new Array(50)];
 </script>

--- a/examples/lists.txt
+++ b/examples/lists.txt
@@ -1,6 +1,5 @@
 <script>
-	import List from 'smelte/src/components/List';
-	import Icon from 'smelte/src/components/Icon';
+  import { List } from "smelte";
 
   const listOneLine = [{
 		text: 'Item 1',

--- a/examples/menus.txt
+++ b/examples/menus.txt
@@ -1,7 +1,8 @@
 <script>
-	import Button from 'smelte/src/components/Button';
-	import Menu from 'smelte/src/components/Menu';
-	import List from 'smelte/src/components/List';
+  import {
+    Button,
+    Menu,
+  } from "smelte";
 
   let open = true;
 	let selected = "";

--- a/examples/navigation-drawers.txt
+++ b/examples/navigation-drawers.txt
@@ -1,26 +1,30 @@
 <script>
   // This is top src/routes/_layout.svelte.
 
-  import NavigationDrawer from 'smelte/src/components/NavigationDrawer';
-  import { right, elevation, persistent, showNav, showNavMobile, breakpoint } from 'stores.js';
-  import List from 'smelte/src/components/List';
-	import ListItem from 'smelte/src/components/List/ListItem.svelte';
+  import {
+    List,
+    ListItem,
+    NavigationDrawer
+  } from "smelte";
+  import { right, elevation, persistent, showNav } from 'stores.js';
   const menu = [
-      { to: "/components/text-fields", text: 'Text fields' },
-      { to: "/components/buttons", text: 'Buttons' },
-      { to: "/components/selection-controls", text: 'Selection controls' },
-      { to: "/components/lists", text: 'Lists' },
-      ...
+      { to: "components/text-fields", text: 'Text fields' },
+      { to: "components/buttons", text: 'Buttons' },
+      { to: "components/selection-controls", text: 'Selection controls' },
+      { to: "components/lists", text: 'Lists' },
+      { to: "components/navigation-drawers", text: 'Navigation Drawers' },
+      { to: "..", text: 'Go back' },
     ];
+  
+  let path = "components/navigation-drawers";
+
 </script>
 
 <NavigationDrawer
   bind:showDesktop={$showNav}
-  bind:showMobile={$showNavMobile}
   right={$right}
   persistent={$persistent}
   elevation={$elevation}
-  breakpoint={$breakpoint}
 >
   <h6
     class="p-6 ml-1 pb-2 text-xs text-gray-900"

--- a/examples/progress-indicators.txt
+++ b/examples/progress-indicators.txt
@@ -1,8 +1,8 @@
 <script>
-  import ProgressLinear from 'smelte/src/components/ProgressLinear';
-  import ProgressCircular from 'smelte/src/components/ProgressCircular';
-
-  import Code from 'docs/Code.svelte';
+  import {
+    ProgressLinear,
+    ProgressCircular
+  } from "smelte";
 
   let progress = 0;
 

--- a/examples/selects.txt
+++ b/examples/selects.txt
@@ -1,7 +1,5 @@
 <script>
-  import { Select, Checkbox, Card } from "smelte";
-  import Code from "docs/Code.svelte";
-  import selects from "examples/selects.txt";
+  import { Select, Checkbox } from "smelte";
 
   let value1 = "";
   let value2 = "";
@@ -37,8 +35,6 @@
 </p>
 <small>Selected: {value1 || 'nothing'}</small>
 <Select {label} {items} on:change={v => (value1 = v.detail)} />
-
-<Code code={selects} />
 
 <p>
   Or through binding

--- a/examples/sliders.txt
+++ b/examples/sliders.txt
@@ -1,5 +1,8 @@
 <script>
-  import { Slider, Checkbox } from "smelte";
+  import {
+    Slider,
+    Checkbox
+  } from "smelte";
 
   let value = 0;
   let value2 = 0;

--- a/examples/snackbars.txt
+++ b/examples/snackbars.txt
@@ -1,7 +1,11 @@
 <script>
-  import { Snackbar, notifier, Button, Notifications, TextField } from "smelte";
-  import Code from "docs/Code.svelte";
-  import snackbars from "examples/snackbars.txt";
+  import {
+    Snackbar,
+    notifier,
+    Button,
+    Notifications,
+    TextField
+  } from "smelte";
 
   let showSnackbar = false;
   let showSnackbarTop = false;
@@ -64,8 +68,6 @@
     on:click={() => (showSnackbarBottomLeft = true)}>Show snackbar on the bottom left</Button>
 </div>
 
-<Code code={snackbars} />
-
 <p>Also Smelte comes with a simple notification queue implementation.</p>
 
 <TextField bind:value={message} label="New message" />
@@ -74,5 +76,3 @@
   on:click={notify}>Add message to queue</Button>
 
 <Notifications />
-
-<Code code={snackbars} />

--- a/examples/table.txt
+++ b/examples/table.txt
@@ -1,7 +1,22 @@
 <script>
   import { DataTable } from "smelte";
 
-  import data from "./data.json";
+  let data = [];
+  let loading = true;
+
+  async function getData() {
+    if (typeof window === "undefined") return;
+
+    loading = true;
+    const res = await fetch("data.json");
+    const body = await res.json();
+
+    data = body._embedded.episodes;
+
+    setTimeout(() => loading = false, 500);
+  }
+
+  getData();
 </script>
 
 <div class="overflow-auto p-1">

--- a/examples/tabs-with-content.txt
+++ b/examples/tabs-with-content.txt
@@ -1,3 +1,14 @@
+<script>
+	import {
+    Tabs,
+    Tab,
+    Image,
+    TextField
+	} from "smelte";
+
+  let loading = false;
+</script>
+
 <div style="max-width: 400px">
   <Tabs
     selected="1"
@@ -33,7 +44,7 @@
           height="250"
         />
       </Tab>
-        <Tab id="3" {selected}>
+      <Tab id="3" {selected}>
         <Image
           alt="kitten 3"
           class="w-full"
@@ -42,5 +53,6 @@
           height="250"
         />
       </Tab>
+    </div>
   </Tabs>
 </div>

--- a/examples/tabs.txt
+++ b/examples/tabs.txt
@@ -1,4 +1,5 @@
 <script>
+  import { Tabs } from "smelte";
   import { stores } from '@sapper/app';
   const { page } = stores();
 

--- a/examples/text-fields.txt
+++ b/examples/text-fields.txt
@@ -1,8 +1,5 @@
 <script>
-  import TextField from "smelte/src/components/TextField";
-  import Code from "docs/Code.svelte";
-
-  import textFields from "examples/text-fields.txt";
+  import { TextField } from "smelte";
 </script>
 
 <h6 class="mb-3 mt-6">Basic</h6>
@@ -21,5 +18,3 @@
 <TextField label="Test label" textarea rows="5" outlined />
 <h6 class="mb-3 mt-6">With basic validation (type="number" min="10" max="100")</h6>
 <TextField label="Test label" outlined type="number" min="10" max="100" />
-
-<Code code={textFields} />

--- a/examples/treeview.txt
+++ b/examples/treeview.txt
@@ -1,5 +1,5 @@
 <script>
-  import Treeview from "smelte/src/components/Treeview";
+  import { Treeview } from "smelte";
 </script>
 
 <Treeview items={[


### PR DESCRIPTION
**What?**

A simple commit to fix a couple of syntax errors at the **examples** (especially the imports and some references to docs/Code)

**Why?**

To ease the use of Smelte for newcomers (i.e.: I was driving crazy debugging the date picker until I realize the correct value is `i.detail` and not just `i` at the change event)

**How?**
I just copied and pasted the examples in a running Smelte 1.0.15 and try to run them. Then fix a minor error here and a minor error there comparing with the real code.

Thank you for Smelte, it's really cool !!