### PR TITLE
Fix for NavigationDrawer being created with show="false" still displaying on larger screens

### DIFF
--- a/src/components/NavigationDrawer/NavigationDrawer.svelte
+++ b/src/components/NavigationDrawer/NavigationDrawer.svelte
@@ -31,7 +31,8 @@
 
   $: transitionProps.x = right ? 300 : -300;
 
-  // Don't show the drawer if it was created with show="false"
+  // Is the drawer deliberately hidden? Don't let the $bp check make it visible if so.
+  let hidden = !show;
   $: if (!hidden) persistent = show = $bp !== "sm";
 
   const cb = new ClassBuilder(classes, classesDefault);

--- a/src/components/NavigationDrawer/NavigationDrawer.svelte
+++ b/src/components/NavigationDrawer/NavigationDrawer.svelte
@@ -30,7 +30,9 @@
   };
 
   $: transitionProps.x = right ? 300 : -300;
-  $: persistent = show = $bp !== "sm";
+
+  // Don't show the drawer if it was created with show="false"
+  $: if (!hidden) persistent = show = $bp !== "sm";
 
   const cb = new ClassBuilder(classes, classesDefault);
 


### PR DESCRIPTION
Adding the NavigationDrawer  component in your application with `show="false" had no impact because it was being overwritten if the breakpoint wasn't `sm`. This fixes that.