### PR TITLE
Fix for `Uncaught TypeError: window.removeListener is not a function` in breakpoints.js

### DIFF
--- a/src/breakpoints.js
+++ b/src/breakpoints.js
@@ -22,7 +22,7 @@ export default function breakpoint(calcBreakpoint = defaultCalc) {
   const onResize = ({ target }) => store.set(calcBreakpoint(target.innerWidth));
 
   window.addEventListener("resize", onResize);
-  onDestroy(() => window.removeListener(onResize));
+  onDestroy(() => window.removeEventListener("resize", onResize));
 
   return {
     subscribe: store.subscribe

--- a/src/components/NavigationDrawer/NavigationDrawer.svelte
+++ b/src/components/NavigationDrawer/NavigationDrawer.svelte
@@ -31,7 +31,8 @@
 
   $: transitionProps.x = right ? 300 : -300;
 
-  // Don't show the drawer if it was created with show="false"
+  // Is the drawer deliberately hidden? Don't let the $bp check make it visible if so.
+  let hidden = !show;
   $: if (!hidden) persistent = show = $bp !== "sm";
 
   const cb = new ClassBuilder(classes, classesDefault);

--- a/src/components/NavigationDrawer/NavigationDrawer.svelte
+++ b/src/components/NavigationDrawer/NavigationDrawer.svelte
@@ -30,7 +30,9 @@
   };
 
   $: transitionProps.x = right ? 300 : -300;
-  $: persistent = show = $bp !== "sm";
+
+  // Don't show the drawer if it was created with show="false"
+  $: if (!hidden) persistent = show = $bp !== "sm";
 
   const cb = new ClassBuilder(classes, classesDefault);
 


### PR DESCRIPTION
I'm using Svelte Router SPA, which might be why this issue has come up for me, but I think that line needed rewriting anyway.