### PR TITLE
Fix for NavigationDrawer not hiding with when expected

### DIFF
--- a/src/components/NavigationDrawer/NavigationDrawer.svelte
+++ b/src/components/NavigationDrawer/NavigationDrawer.svelte
@@ -30,7 +30,10 @@
   };
 
   $: transitionProps.x = right ? 300 : -300;
-  $: persistent = show = $bp !== "sm";
+
+  // Is the drawer deliberately hidden? Don't let the $bp check make it visible if so.
+  let hidden = !show;
+  $: if (!hidden) persistent = show = $bp !== "sm";
 
   const cb = new ClassBuilder(classes, classesDefault);
 


### PR DESCRIPTION
Creating a NavigationDrawer component with the `show` property set to `false`, it wasn't hiding the drawer on larger screens. It was being overriden by this line:
```
$: persistent = show = $bp !== "sm";
```

I've added a variable called `hidden`, set to the original `show` value set. Only if it's false do we run the check above.