### PR TITLE
Fix for destroying event listener in breakpoints.js

### DIFF
--- a/src/breakpoints.js
+++ b/src/breakpoints.js
@@ -22,7 +22,7 @@ export default function breakpoint(calcBreakpoint = defaultCalc) {
   const onResize = ({ target }) => store.set(calcBreakpoint(target.innerWidth));
 
   window.addEventListener("resize", onResize);
-  onDestroy(() => window.removeListener(onResize));
+  onDestroy(() => window.removeEventListener("resize", onResize));
 
   return {
     subscribe: store.subscribe

--- a/src/components/NavigationDrawer/NavigationDrawer.svelte
+++ b/src/components/NavigationDrawer/NavigationDrawer.svelte
@@ -30,7 +30,10 @@
   };
 
   $: transitionProps.x = right ? 300 : -300;
-  $: persistent = show = $bp !== "sm";
+
+  // Is the drawer deliberately hidden? Don't let the $bp check make it visible if so.
+  let hidden = !show;
+  $: if (!hidden) persistent = show = $bp !== "sm";
 
   const cb = new ClassBuilder(classes, classesDefault);
 


### PR DESCRIPTION
I suspect I've only ran into this because I'm using the Svelte Router SPA but when the path changes, there was a JS error over the resize event listener being destroyed. 