### PR TITLE
Fix for destroying event listener in breakpoints.js

### DIFF
--- a/src/breakpoints.js
+++ b/src/breakpoints.js
@@ -22,7 +22,7 @@ export default function breakpoint(calcBreakpoint = defaultCalc) {
   const onResize = ({ target }) => store.set(calcBreakpoint(target.innerWidth));
 
   window.addEventListener("resize", onResize);
-  onDestroy(() => window.removeListener(onResize));
+  onDestroy(() => window.removeEventListener("resize", onResize));
 
   return {
     subscribe: store.subscribe


### PR DESCRIPTION
It's probably only come to light because I'm using Svelte Router SPA but the changing paths looking to be calling OnDestroy in breakpoints.js. It was just incorrect wording and the missing listener name.