### PR TITLE
Improving support for manually entered dates

### DIFF
--- a/src/components/DatePicker/DatePicker.svelte
+++ b/src/components/DatePicker/DatePicker.svelte
@@ -38,15 +38,17 @@
   }
 
   function changeTextInput(e) {
-    const date = new Date(e.target.value);
 
-    if (valid(date)) {
-      value = date;
-    }
+    let date;
+    const dateArray = e.target.value.split(/\D+/);
+    if (dateArray[2].length == 4) date = new Date(dateArray[2], dateArray[1]-1, dateArray[0]);
+    else date = new Date(dateArray[0], dateArray[1]-1, dateArray[2]);
+    if (valid(date)) value = date;
 
     if (e.target.value === '') {
       value = null;
     }
+    
   }
 
   $: if (dense) {

--- a/src/components/DatePicker/DatePicker.svelte
+++ b/src/components/DatePicker/DatePicker.svelte
@@ -63,6 +63,7 @@
       {dense}
       append={defaultIcon}
       {appendClasses}
+      on:click={() => open = !open}
       on:click-append={() => open = !open}
       on:change={changeTextInput}
     />


### PR DESCRIPTION
1. Clicking in the DatePicker's TextField opens the DatePicker. I know this isn't default behaviour in the Material UI library but I think it's a good stopgap until manually entering dates is better supported.
2. Once a date has been selected, users can edit the date and it'll be valid, providing its format matches DD/MM/YYYY or YYYY/MM/DD.