### PR TITLE
Move svelte-typed-component to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "tailwind-css-variables": "^2.0.3",
     "tailwindcss": "^1.4.6",
     "tailwindcss-elevation": "^0.3.0",
-    "tinycolor2": "^1.4.1"
+    "tinycolor2": "^1.4.1",
+    "svelte-typed-component": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -76,7 +77,6 @@
     "rollup-plugin-svelte": "^5.0.1",
     "rollup-plugin-terser": "^5.1.3",
     "sapper": "^0.27.8",
-    "sirv": "^0.4.0",
-    "svelte-typed-component": "^1.1.1"
+    "sirv": "^0.4.0"
   }
 }


### PR DESCRIPTION
The types only work if svelte-typed-component is also installed. I thought previously, that dev-dependencies would also be pulled, but it does not seem to be the case. 