### PR TITLE
Fixed slider gradient for different value ranges

### DIFF
--- a/src/components/Slider/Slider.svelte
+++ b/src/components/Slider/Slider.svelte
@@ -15,9 +15,11 @@
 
   export let classes = classesDefault;
 
-  $: percentFactor = 100.0 / (max - min);
-
-  const toPercent = v => (v - min) * percentFactor;
+  let toPercent;
+  $: {
+    let factor = 100.0 / (max - min);
+    toPercent = v => (v - min) * factor;
+  }
 
   const cb = new ClassBuilder(classes, classesDefault);
 

--- a/src/components/Slider/Slider.svelte
+++ b/src/components/Slider/Slider.svelte
@@ -15,6 +15,9 @@
 
   export let classes = classesDefault;
 
+  $: percentFactor = 100.0 / (max - min);
+
+  const toPercent = v => (v - min) * percentFactor;
 
   const cb = new ClassBuilder(classes, classesDefault);
 
@@ -30,9 +33,10 @@
   $: {
     let c1 = getColor(`--color-${color}-500`);
     let c2 = getColor(`--color-${color}-200`);
+    let cv = toPercent(value);
     style = disabled
     ? ""
-    : `background: linear-gradient(to right, ${c1} 0%, ${c1} ${value}%, ${c2} ${value}%, ${c2} 100%); --bg: ${c1}; --bg-focus: ${c1}`;
+    : `background: linear-gradient(to right, ${c1} 0%, ${c1} ${cv}%, ${c2} ${cv}%, ${c2} 100%); --bg: ${c1}; --bg-focus: ${c1}`;
   }
 
   function applyColor(node) {


### PR DESCRIPTION
The `value` incorrectly treated as percents for calculating slider gradients.
I fixed this by converting it from min..max range to 0..100.