### PR TITLE
Data table refactor

### DIFF
--- a/src/components/DataTable/DataTable.svelte
+++ b/src/components/DataTable/DataTable.svelte
@@ -15,8 +15,7 @@
 
   const classesDefault = "elevation-3 relative text-sm overflow-x-auto dark:bg-dark-500";
 
-
-
+  function defaultHeaderClick() { console.log('default header click') }
 
   export let data = [];
   export let columns = Object.keys(data[0] || {})
@@ -38,9 +37,12 @@
   export let editableClasses = i => i;
   export let paginatorProps = null;
   export let classes = classesDefault;
+  export let customHeaderClick = false;
+  export let headerClick = defaultHeaderClick;
+  export let showSort = false;
+  export let sortBy = null;
 
   let table = "";
-  let sortBy = null;
 
   $: {
     perPage = pagination ? perPage : data.length;
@@ -64,16 +66,17 @@
 <table class={c} bind:this={table}>
   <thead class="items-center">
     {#each columns as column, i}
-      <slot name="header">
         <Header
           class={headerClasses}
           {column}
           bind:asc
           bind:sortBy
           {sortable}
+          {showSort}
           {editing}
+          {customHeaderClick}
+          on:click={headerClick}
         />
-      </slot>
     {/each}
   </thead>
   {#if loading && !hideProgress}

--- a/src/components/DataTable/DataTable.svelte
+++ b/src/components/DataTable/DataTable.svelte
@@ -16,8 +16,6 @@
   const classesDefault = "elevation-3 relative text-sm overflow-x-auto dark:bg-dark-500";
 
   function defaultHeaderClick() { console.log('default header click') }
-  function defaultPaginationClickForward() { console.log('default pagination click forward') }
-  function defaultPaginationClickBack() { console.log('default pagination click back') }
 
   export let data = [];
   export let columns = Object.keys(data[0] || {})
@@ -42,9 +40,6 @@
   export let customSort = false;
   export let customHeaderClick = false;
   export let headerClick = defaultHeaderClick;
-  export let customPaginationClick = false;
-  export let paginationClickForward = defaultPaginationClickForward;
-  export let paginationClickBack = defaultPaginationClickBack;
   export let showSort = false;
   export let sortBy = null;
   export let showPerPageOptions = true;
@@ -125,9 +120,6 @@
         {table}
         {total}
         {showPerPageOptions}
-        {customPaginationClick}
-        on:clickForward={paginationClickForward}
-        on:clickBack={paginationClickBack}
       />
     </slot>
   {/if}

--- a/src/components/DataTable/DataTable.svelte
+++ b/src/components/DataTable/DataTable.svelte
@@ -42,21 +42,15 @@
   export let headerClick = defaultHeaderClick;
   export let showSort = false;
   export let sortBy = null;
-  export let showPerPageOptions = true;
-  export let pagesCount;
-  export let total;
 
   let table = "";
 
   $: {
-    if (!total) {
-      total = data.length;
-    }
     perPage = pagination ? perPage : data.length;
-    pagesCount = Math.ceil(total / perPage);
   }
   $: offset = (page * perPage) - perPage;
   $: sorted = (customSort) ? data : sort(data, sortBy, asc).slice(offset, perPage + offset);
+  $: pagesCount = Math.ceil(data.length / perPage);
 
   const dispatch = createEventDispatcher();
 
@@ -73,6 +67,7 @@
 <table class={c} bind:this={table}>
   <thead class="items-center">
     {#each columns as column, i}
+      <slot name="header">
         <Header
           class={headerClasses}
           {column}
@@ -84,6 +79,7 @@
           {customHeaderClick}
           on:click={headerClick}
         />
+      </slot>
     {/each}
   </thead>
   {#if loading && !hideProgress}
@@ -118,8 +114,7 @@
         {offset}
         {pagesCount}
         {table}
-        {total}
-        {showPerPageOptions}
+        total={data.length}
       />
     </slot>
   {/if}

--- a/src/components/DataTable/DataTable.svelte
+++ b/src/components/DataTable/DataTable.svelte
@@ -16,6 +16,8 @@
   const classesDefault = "elevation-3 relative text-sm overflow-x-auto dark:bg-dark-500";
 
   function defaultHeaderClick() { console.log('default header click') }
+  function defaultPaginationClickForward() { console.log('default pagination click forward') }
+  function defaultPaginationClickBack() { console.log('default pagination click back') }
 
   export let data = [];
   export let columns = Object.keys(data[0] || {})
@@ -37,19 +39,29 @@
   export let editableClasses = i => i;
   export let paginatorProps = null;
   export let classes = classesDefault;
+  export let customSort = false;
   export let customHeaderClick = false;
   export let headerClick = defaultHeaderClick;
+  export let customPaginationClick = false;
+  export let paginationClickForward = defaultPaginationClickForward;
+  export let paginationClickBack = defaultPaginationClickBack;
   export let showSort = false;
   export let sortBy = null;
+  export let showPerPageOptions = true;
+  export let pagesCount;
+  export let total;
 
   let table = "";
 
   $: {
+    if (!total) {
+      total = data.length;
+    }
     perPage = pagination ? perPage : data.length;
+    pagesCount = Math.ceil(total / perPage);
   }
   $: offset = (page * perPage) - perPage;
-  $: sorted = sort(data, sortBy, asc).slice(offset, perPage + offset);
-  $: pagesCount = Math.ceil(data.length / perPage);
+  $: sorted = (customSort) ? data : sort(data, sortBy, asc).slice(offset, perPage + offset);
 
   const dispatch = createEventDispatcher();
 
@@ -111,7 +123,11 @@
         {offset}
         {pagesCount}
         {table}
-        total={data.length}
+        {total}
+        {showPerPageOptions}
+        {customPaginationClick}
+        on:clickForward={paginationClickForward}
+        on:clickBack={paginationClickBack}
       />
     </slot>
   {/if}

--- a/src/components/DataTable/Header.svelte
+++ b/src/components/DataTable/Header.svelte
@@ -5,10 +5,7 @@
 
   const classesDefault = "capitalize duration-100 text-gray-600 text-xs hover:text-black dark-hover:text-white p-3 font-normal text-right";
 
-
   export let classes = classesDefault;
-
-
   export let column = {};
   export let asc = false;
   export let sortBy = false;

--- a/src/components/DataTable/Header.svelte
+++ b/src/components/DataTable/Header.svelte
@@ -14,6 +14,8 @@
   export let sortBy = false;
   export let sortable = true;
   export let editing = false;
+  export let customHeaderClick = false;
+  export let showSort = false;
 
   const dispatch = createEventDispatcher();
 
@@ -49,6 +51,12 @@
   class={c}
   class:cursor-pointer={sortable || column.sortable}
   on:click={() => {
+    if (customHeaderClick && !!column.sortable) {
+      sortBy = column;
+      asc = sortBy === column ? !asc : false;
+      dispatch("click");
+      return;
+    }
     if (column.sortable === false || !sortable) return;
     dispatch("sort", column);
 
@@ -57,17 +65,37 @@
     sortBy = column;
   }}
 >
-  <div class={headerColumnClass(column)}>
-    {#if sortable && column.sortable !== false && !column.iconAfter}
+  {#if showSort}
+    <div class={headerColumnClass(column)}>
+      {#if sortable && column.sortable !== false && !column.iconAfter}
+        {#if sortBy === column}
+          <span class:asc={!asc}>
+            <Icon small color="text-gray-400 dark:text-gray-100">arrow_downward</Icon>
+          </span>
+        {/if}
+      {/if}
+      <span>{column.label || column.field}</span>
+      {#if sortable && column.sortable !== false && !!column.iconAfter}
+        {#if sortBy === column}
+          <span class:asc={!asc}>
+            <Icon small color="text-gray-400 dark:text-gray-100">arrow_downward</Icon>
+          </span>
+        {/if}
+      {/if}
+    </div>
+  {:else}
+    <div class={headerColumnClass(column)}>
+      {#if sortable && column.sortable !== false && !column.iconAfter}
       <span class="sort" class:asc={!asc && sortBy === column}>
         <Icon small color="text-gray-400 dark:text-gray-100">arrow_downward</Icon>
       </span>
-    {/if}
-    <span>{column.label || column.field}</span>
-    {#if sortable && column.sortable !== false && !!column.iconAfter}
+      {/if}
+      <span>{column.label || column.field}</span>
+      {#if sortable && column.sortable !== false && !!column.iconAfter}
       <span class="sort" class:asc={!asc && sortBy === column}>
         <Icon small color="text-gray-400 dark:text-gray-100">arrow_downward</Icon>
       </span>
-    {/if}
-  </div>
+      {/if}
+    </div>
+  {/if}
 </th>

--- a/src/components/DataTable/Pagination.svelte
+++ b/src/components/DataTable/Pagination.svelte
@@ -21,7 +21,10 @@
       .replace("text-gray-700", ""),
   };
 
+
   export let classes = classesDefault;
+
+
   export let perPage = 0;
   export let page = 0;
   export let offset = 0;
@@ -30,8 +33,7 @@
   export let scrollToTop = false;
   export let table = null;
   export let total = 0;
-  export let showPerPageOptions = true;
-  export let customPaginationClick = false;
+
   export let paginatorProps = false;
 
   const dispatch = createEventDispatcher();
@@ -45,51 +47,43 @@
 </script>
 
 <tfoot>
-  <tr>
-    <td colspan="100%" class="border-none">
-      <div class={c}>
-        <Spacer />
-        {#if showPerPageOptions}
-          <div class="mr-1 py-1">
-          Rows per page:
-          </div>
-          <Select
-            class="w-16 h-8 mb-5"
-            remove="select"
-            replace={{ "pt-6": "pt-4" }}
-            inputWrapperClasses={(c) => c.replace("mt-2", "").replace("pb-6", "")}
-            appendClasses={(c) => c.replace("pt-4", "pt-3").replace("pr-4", "pr-2")}
-            noUnderline
-            dense
-            bind:value={perPage}
-            items={perPageOptions}
-          />
-        {/if}
-        <Spacer />
-        <div>{offset}-{offset + perPage > total ? total : offset + perPage} of {total}</div>
-        <Button
-          disabled={(page - 1) < 1}
-          icon="keyboard_arrow_left"
-          {...(paginatorProps || paginatorPropsDefault)}
-          on:click={() => {
+<tr>
+  <td colspan="100%" class="border-none">
+    <div class={c}>
+      <Spacer />
+      <div class="mr-1 py-1">
+        Rows per page:
+      </div>
+      <Select
+              class="w-16 h-8 mb-5"
+              remove="select"
+              replace={{ "pt-6": "pt-4" }}
+              inputWrapperClasses={(c) => c.replace("mt-2", "").replace("pb-6", "")}
+              appendClasses={(c) => c.replace("pt-4", "pt-3").replace("pr-4", "pr-2")}
+              noUnderline
+              dense
+              bind:value={perPage}
+              items={perPageOptions}
+      />
+      <Spacer />
+      <div>{offset}-{offset + perPage > total ? total : offset + perPage} of {total}</div>
+      <Button
+              disabled={(page - 1) < 1}
+              icon="keyboard_arrow_left"
+              {...(paginatorProps || paginatorPropsDefault)}
+              on:click={() => {
             page -= 1;
             if (scrollToTop) table.scrollIntoView({ behavior: "smooth" });
-            if (customPaginationClick) {
-              dispatch("clickBack");
-            }
           }} />
-        <Button
-          disabled={page === pagesCount}
-          icon="keyboard_arrow_right"
-          {...(paginatorProps || paginatorPropsDefault)}
-          on:click={() => {
+      <Button
+              disabled={page === pagesCount}
+              icon="keyboard_arrow_right"
+              {...(paginatorProps || paginatorPropsDefault)}
+              on:click={() => {
             page += 1;
             if (scrollToTop) table.scrollIntoView({ behavior: "smooth" });
-            if (customPaginationClick) {
-              dispatch("clickForward");
-            }
           }} />
-        </div>
-      </td>
-    </tr>
-  </tfoot>
+    </div>
+  </td>
+</tr>
+</tfoot>

--- a/src/components/DataTable/Pagination.svelte
+++ b/src/components/DataTable/Pagination.svelte
@@ -47,43 +47,43 @@
 </script>
 
 <tfoot>
-<tr>
-  <td colspan="100%" class="border-none">
-    <div class={c}>
-      <Spacer />
-      <div class="mr-1 py-1">
+  <tr>
+    <td colspan="100%" class="border-none">
+      <div class={c}>
+        <Spacer />
+        <div class="mr-1 py-1">
         Rows per page:
-      </div>
-      <Select
-              class="w-16 h-8 mb-5"
-              remove="select"
-              replace={{ "pt-6": "pt-4" }}
-              inputWrapperClasses={(c) => c.replace("mt-2", "").replace("pb-6", "")}
-              appendClasses={(c) => c.replace("pt-4", "pt-3").replace("pr-4", "pr-2")}
-              noUnderline
-              dense
-              bind:value={perPage}
-              items={perPageOptions}
-      />
-      <Spacer />
-      <div>{offset}-{offset + perPage > total ? total : offset + perPage} of {total}</div>
-      <Button
-              disabled={(page - 1) < 1}
-              icon="keyboard_arrow_left"
-              {...(paginatorProps || paginatorPropsDefault)}
-              on:click={() => {
+        </div>
+        <Select
+          class="w-16 h-8 mb-5"
+          remove="select"
+          replace={{ "pt-6": "pt-4" }}
+          inputWrapperClasses={(c) => c.replace("mt-2", "").replace("pb-6", "")}
+          appendClasses={(c) => c.replace("pt-4", "pt-3").replace("pr-4", "pr-2")}
+          noUnderline
+          dense
+          bind:value={perPage}
+          items={perPageOptions}
+        />
+        <Spacer />
+        <div>{offset}-{offset + perPage > total ? total : offset + perPage} of {total}</div>
+        <Button
+          disabled={(page - 1) < 1}
+          icon="keyboard_arrow_left"
+          {...(paginatorProps || paginatorPropsDefault)}
+          on:click={() => {
             page -= 1;
             if (scrollToTop) table.scrollIntoView({ behavior: "smooth" });
           }} />
-      <Button
-              disabled={page === pagesCount}
-              icon="keyboard_arrow_right"
-              {...(paginatorProps || paginatorPropsDefault)}
-              on:click={() => {
+        <Button
+          disabled={page === pagesCount}
+          icon="keyboard_arrow_right"
+          {...(paginatorProps || paginatorPropsDefault)}
+          on:click={() => {
             page += 1;
             if (scrollToTop) table.scrollIntoView({ behavior: "smooth" });
           }} />
-    </div>
-  </td>
-</tr>
-</tfoot>
+        </div>
+      </td>
+    </tr>
+  </tfoot>

--- a/src/components/DataTable/Pagination.svelte
+++ b/src/components/DataTable/Pagination.svelte
@@ -21,10 +21,7 @@
       .replace("text-gray-700", ""),
   };
 
-
   export let classes = classesDefault;
-
-
   export let perPage = 0;
   export let page = 0;
   export let offset = 0;
@@ -33,7 +30,8 @@
   export let scrollToTop = false;
   export let table = null;
   export let total = 0;
-
+  export let showPerPageOptions = true;
+  export let customPaginationClick = false;
   export let paginatorProps = false;
 
   const dispatch = createEventDispatcher();
@@ -51,20 +49,22 @@
     <td colspan="100%" class="border-none">
       <div class={c}>
         <Spacer />
-        <div class="mr-1 py-1">
-        Rows per page:
-        </div>
-        <Select
-          class="w-16 h-8 mb-5"
-          remove="select"
-          replace={{ "pt-6": "pt-4" }}
-          inputWrapperClasses={(c) => c.replace("mt-2", "").replace("pb-6", "")}
-          appendClasses={(c) => c.replace("pt-4", "pt-3").replace("pr-4", "pr-2")}
-          noUnderline
-          dense
-          bind:value={perPage}
-          items={perPageOptions}
-        />
+        {#if showPerPageOptions}
+          <div class="mr-1 py-1">
+          Rows per page:
+          </div>
+          <Select
+            class="w-16 h-8 mb-5"
+            remove="select"
+            replace={{ "pt-6": "pt-4" }}
+            inputWrapperClasses={(c) => c.replace("mt-2", "").replace("pb-6", "")}
+            appendClasses={(c) => c.replace("pt-4", "pt-3").replace("pr-4", "pr-2")}
+            noUnderline
+            dense
+            bind:value={perPage}
+            items={perPageOptions}
+          />
+        {/if}
         <Spacer />
         <div>{offset}-{offset + perPage > total ? total : offset + perPage} of {total}</div>
         <Button
@@ -74,6 +74,9 @@
           on:click={() => {
             page -= 1;
             if (scrollToTop) table.scrollIntoView({ behavior: "smooth" });
+            if (customPaginationClick) {
+              dispatch("clickBack");
+            }
           }} />
         <Button
           disabled={page === pagesCount}
@@ -82,6 +85,9 @@
           on:click={() => {
             page += 1;
             if (scrollToTop) table.scrollIntoView({ behavior: "smooth" });
+            if (customPaginationClick) {
+              dispatch("clickForward");
+            }
           }} />
         </div>
       </td>


### PR DESCRIPTION
These changes allow server-side sorting.
`customSort` tells the table to not do client side sort and slice.
`showSort` tells the table to show the sort icon on the column that is currently sorted.
`customHeaderClick` tells the table to not handle the header sort clicks.  It will then dispatch a `headerClick`
`headerClick` - do the sorting work when the header is clicked