### PR TITLE
Unselectable icon by default

### DIFF
--- a/src/components/Icon/Icon.svelte
+++ b/src/components/Icon/Icon.svelte
@@ -20,7 +20,7 @@
 
 <i
   aria-hidden="true"
-  class="material-icons icon text-xl {$$props.class} duration-200 ease-in"
+  class="material-icons icon text-xl select-none {$$props.class} duration-200 ease-in"
   class:reverse
   class:tip
   on:click


### PR DESCRIPTION
Make icons **unselectable** by default.

This will prevent undesirable behavior like this:
![user-select-checkbox](https://user-images.githubusercontent.com/44581623/100073508-e2547280-2e3d-11eb-9461-4af712df53c2.png)
![user-select-chips](https://user-images.githubusercontent.com/44581623/100073518-e41e3600-2e3d-11eb-9332-48df17cefc0e.png)
![user-select-radio](https://user-images.githubusercontent.com/44581623/100073522-e54f6300-2e3d-11eb-85f2-9695723e4b3f.png)

By making icons unselectable:

![no-user-select-checkbox](https://user-images.githubusercontent.com/44581623/100073553-ef716180-2e3d-11eb-99b0-603cb2e3e22c.png)
![no-user-select-chips](https://user-images.githubusercontent.com/44581623/100073820-42e3af80-2e3e-11eb-81e0-d934712e6578.png)
![no-user-select-radio](https://user-images.githubusercontent.com/44581623/100073826-45460980-2e3e-11eb-9ef6-a470db04f0cb.png)


This will also prevent weird copy/past when element contain an icon. For example, if we copy/paste the first checkbox of the screenshot:
- With user selectable icons:
  `check_box_outline_blank A checkbox`
- With non user selectable icons:
  `A checkbox`

