### PR TITLE
Add a default type to the button.

### DIFF
--- a/src/components/Button/Button.svelte
+++ b/src/components/Button/Button.svelte
@@ -19,6 +19,7 @@
   export let color = "primary";
   export let href = null;
   export let fab = false;
+  export let type = "button";
 
   export let remove = "";
   export let add = "";
@@ -136,6 +137,7 @@
       use:ripple
       class={classes}
       {...props}
+      {type}
       {disabled}
       on:click={() => (value = !value)}
       on:click
@@ -153,6 +155,7 @@
     use:ripple
     class={classes}
     {...props}
+    {type}
     {disabled}
     on:click={() => (value = !value)}
     on:click


### PR DESCRIPTION
Fixes #204 

When adding a button inside a form, the button type is by default 'empty' (for instance for the date picker). Having it default to `type="button"` the next and previous buttons will not trigger a form submit.
