### PR TITLE
fix: check whether today is in the same year

### DIFF
--- a/src/components/DatePicker/Picker.svelte
+++ b/src/components/DatePicker/Picker.svelte
@@ -52,6 +52,7 @@
   $: lastDayOfMonth = new Date(temp.getFullYear(), temp.getMonth() + 1, 0);
   $: firstDayOfMonth = new Date(temp.getFullYear(), temp.getMonth(), 1);
   $: isCurrentMonth = (new Date()).getMonth() === temp.getMonth();
+  $: isCurrentYear = (new Date()).getYear() === temp.getYear();
 
   function dayIsSelected(day) {
     if (!value) return false;
@@ -64,7 +65,7 @@
   $: daysInMonth = [...new Array(lastDayOfMonth.getDate() || 0)]
       .map((i, j) => ({
         day: j + 1,
-        isToday: isCurrentMonth && j + 1 === today,
+        isToday: isCurrentYear && isCurrentMonth && j + 1 === today,
         selected: dayIsSelected(j + 1),
       }));
 


### PR DESCRIPTION
When having the picker open, it highlights the current day. It also highlighted the current day in other years as well.
The value 'isToday' suggests that it should only highlight the 'today' value, and not the same dates in other years as well.

This PR fixes #202.