### PR TITLE
docs: suggest placement of rollup plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get you started you need to add Smelte to your dependencies with your favorit
 $ npm install smelte or yarn add smelte
 ```
 
-Then you need to add Smelte Rollup plugin (Webpack is on its way).
+Then add the Smelte Rollup plugin (after svelte but before css). Webpack support coming soon.
 
 ```js
 const smelte = require("smelte/rollup-plugin-smelte");

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -40,7 +40,7 @@
 To get you started you need to add Smelte to your dependencies with your
 favorite package manager.
 <Code code="$ npm install smelte or yarn add smelte" />
-Then you need to add Smelte Rollup plugin (Webpack is on its way).
+Then add the Smelte Rollup plugin (after svelte but before css). Webpack support coming soon.
 <Code
   code={`const smelte=require("smelte/rollup-plugin-smelte");
 


### PR DESCRIPTION
This adds clarification for where to put the rollup plugin

closes #210