### PR TITLE
Expose type definition files

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,16 @@
     "src/utils",
     "src/tailwind.css",
     "src/index.js",
+    "src/index.d.ts",
     "src/breakpoints.js",
+    "src/breakpoints.d.ts",
     "src/notification-queue.js",
+    "src/notification-queue.d.ts",
     "src/components",
     "tailwind.config.js",
     "postcss.config.js",
     "src/dark.js",
+    "src/dark.d.ts",
     "rollup-plugin-smelte.js"
   ],
   "module": "dist/module.js",
@@ -35,6 +39,7 @@
     "postcss-input-range": "^4.0.0",
     "postcss-url": "^10.1.1",
     "svelte": "^3.31.2",
+    "svelte-typed-component": "^1.1.1",
     "tailwind-css-variables": "^2.0.3",
     "tailwindcss": "^2.0.3",
     "tinycolor2": "^1.4.2"
@@ -74,7 +79,6 @@
     "sapper": "^0.28.10",
     "sirv": "^0.4.6",
     "svelte-preprocess": "^3.9.11",
-    "svelte-typed-component": "^1.1.1",
     "svelte-waypoint": "^0.1.4"
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -26,5 +26,6 @@ import Ripple from "./components/Ripple";
 import DatePicker from "./components/DatePicker";
 import breakpoints from "./breakpoints";
 import notificationQueue from "./notification-queue";
+import dark from "./dark";
 export { Scrim, Spacer } from "./components/Util";
-export { Button, Card, Chip, Dialog, Image, Checkbox, SelectionLabel, RadioButton, RadioButtonGroup, List, ListItem, Menu, Label, NavigationDrawer, Icon, ProgressLinear, ProgressCircular, Select, Slider, Snackbar, Tab, Tabs, TabButton, TextField, AppBar, DataTable, Treeview, Switch, Tooltip, Ripple, DatePicker, breakpoints, notifier, notificationQueue, Notifications };
+export { Button, Card, Chip, Dialog, Image, Checkbox, SelectionLabel, RadioButton, RadioButtonGroup, List, ListItem, Menu, Label, NavigationDrawer, Icon, ProgressLinear, ProgressCircular, Select, Slider, Snackbar, Tab, Tabs, TabButton, TextField, AppBar, DataTable, Treeview, Switch, Tooltip, Ripple, DatePicker, breakpoints, notifier, notificationQueue, dark, Notifications };

--- a/src/notification-queue.d.ts
+++ b/src/notification-queue.d.ts
@@ -1,9 +1,7 @@
-import {right} from "./stores";
-
 type _writable = import("svelte/store").Writable<[]>;
 
 export default function notificationQueue(): {
-    subscribe: typeof right.subscribe,
+    subscribe: typeof _writable.subscribe,
     notify: (message: string) => void,
     error: (message: string) => void,
     alert: (message: string) => void,


### PR DESCRIPTION
When `smelte` is used with `typescript`, the compiler is confused because the file `src/index.d.ts` isn't part of the package. Adding them to the bundle fixes that problem. `svelte-typed-component` is imported from those file definitions. Moving that dependency from `devDependencies` to `dependencies` fixes that import.

I didn't find any contribution guidelines, let me know if that's the right way of helping :wink: Also, well done for your good work :clap: 

Closes #166, closes #109 