### PR TITLE
Correct Tab.selected prop to match usage

### DIFF
--- a/src/components/Tabs/Tab.d.ts
+++ b/src/components/Tabs/Tab.d.ts
@@ -10,9 +10,9 @@ export default class Tab extends SvelteTypedComponent<TabProps, TabEvents, TabSl
 declare const _TabProps: {
     /** Selectd
      * 
-     * Default: false
+     * Default: undefined
      */
-    selected?: boolean;
+    selected?: string;
     /** ID
      * 
      * Default: null

--- a/src/components/Tabs/Tab.svelte
+++ b/src/components/Tabs/Tab.svelte
@@ -1,5 +1,5 @@
 <script>
-  export let selected = false;
+  export let selected = undefined;
   export let id = null;
 </script>
 


### PR DESCRIPTION
This matches how it's used in the `#if` block and defaults to not matching (`undefined !== null`).

Excerpt from the web guide that uses it as well:

```svelte
  <Tabs
    selected="1"
    class="bg-black shadow-sm mt-6 text-white rounded-t-lg"
    color="yellow-a200"
    let:selected={selected}
    {loading}
    items={[
      { id: "1", text: 'Cats', icon: 'alarm_on' },
      { id: "2", text: 'Kittens', icon: 'bug_report' },
      { id: "3", text: 'Kitties', icon: 'eject' },
    ]}>
    <div
      slot="content"
      class="flex items-center content-center overflow-hidden w-full bg-gray-900 h-full"
      style="height: 250px"
    >
      <Tab id="1" {selected}>
        <Image
          alt="kitten 1"
          class="w-full"
          src="https://placekitten.com/400/250"
          width="400"
          height="250"
        />
      </Tab>
```

Where the `selected` variable is the items' `id`.