### PR TITLE
Fix TextField Underline color mismatch issue

### DIFF
--- a/src/components/TextField/TextField.svelte
+++ b/src/components/TextField/TextField.svelte
@@ -240,7 +240,8 @@
     {noUnderline}
     {outlined}
     {focused}
-    {error} />
+    {error} 
+    {color}  />
 
   {#if showHint}
     <Hint


### PR DESCRIPTION
Fixed an issue causing the color of the underline to not change properly with the color attribute of TextField

I noticed an issue while working on a side project that the Underline does not have the `color` prop passed down to it from the TextField so I added that prop in.