### PR TITLE
Fix List slot typings

### DIFF
--- a/src/components/List/List.d.ts
+++ b/src/components/List/List.d.ts
@@ -37,7 +37,11 @@ declare const _ListEvents: {
 };
 declare const _ListSlots: {
     item: {
-        item: {};
+        item: ListItemBase;
+        dense: boolean;
+        value: string;
+    };
+    items: {
         dense: boolean;
         value: string;
     };


### PR DESCRIPTION
Changes the `item` prop type to `ListItemBase` instead of `{}`, and adds the new `items` slot introduced in #258.