### PR TITLE
Add 100 color variant instead of duplicate 50 variant

### DIFF
--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -46,19 +46,19 @@ function buildPalette(hex) {
   const baseDark = multiply(tinycolor(hex).toRgb(), tinycolor(hex).toRgb());
   const baseTriad = tinycolor(hex).tetrad();
 
-  const lightest = o(tinycolor.mix(white, hex, 12), "50");
+  const transBase = o(tinycolor.mix(white, hex, 30), "50");
   return {
-    transLight: tinycolor(lightest[50])
+    transLight: tinycolor(transBase[50])
       .toRgbString()
       .replace(")", ", 0.15)"),
-    trans: tinycolor(lightest[50])
+    trans: tinycolor(transBase[50])
       .toRgbString()
       .replace(")", ", 0.7)"),
     transDark: tinycolor(hex)
       .toRgbString()
       .replace(")", ", 0.15)"),
 
-    ...lightest,
+    ...o(tinycolor.mix(white, hex, 12), "50"),
     ...o(tinycolor.mix(white, hex, 30), "100"),
     ...o(tinycolor.mix(white, hex, 50), "200"),
     ...o(tinycolor.mix(white, hex, 70), "300"),

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -46,7 +46,7 @@ function buildPalette(hex) {
   const baseDark = multiply(tinycolor(hex).toRgb(), tinycolor(hex).toRgb());
   const baseTriad = tinycolor(hex).tetrad();
 
-  const lightest = o(tinycolor.mix(white, hex, 30), "100");
+  const lightest = o(tinycolor.mix(white, hex, 12), "50");
   return {
     transLight: tinycolor(lightest[50])
       .toRgbString()
@@ -58,8 +58,8 @@ function buildPalette(hex) {
       .toRgbString()
       .replace(")", ", 0.15)"),
 
-    ...o(tinycolor.mix(white, hex, 12), "50"),
     ...lightest,
+    ...o(tinycolor.mix(white, hex, 30), "100"),
     ...o(tinycolor.mix(white, hex, 50), "200"),
     ...o(tinycolor.mix(white, hex, 70), "300"),
     ...o(tinycolor.mix(white, hex, 85), "400"),

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -19,6 +19,7 @@ const white = tinycolor("#ffffff");
 function buildPaletteByVarColor(varColor) {
   return {
     "50": `var(${varColor}-50)`,
+    "100": `var(${varColor}-100)`,
     "200": `var(${varColor}-200)`,
     "300": `var(${varColor}-300)`,
     "400": `var(${varColor}-400)`,
@@ -45,7 +46,7 @@ function buildPalette(hex) {
   const baseDark = multiply(tinycolor(hex).toRgb(), tinycolor(hex).toRgb());
   const baseTriad = tinycolor(hex).tetrad();
 
-  const lightest = o(tinycolor.mix(white, hex, 30), "50");
+  const lightest = o(tinycolor.mix(white, hex, 30), "100");
   return {
     transLight: tinycolor(lightest[50])
       .toRgbString()


### PR DESCRIPTION
Fixes #292 

This attempts to preserve as much of existing behavior as possible while fixing the error caused for 100 by https://github.com/matyunya/smelte/commit/e84371fdff6db98f01a7ebbcf16e42707c0efb3c

Unavoidable change from the above commit is that "50" is now properly assigned to     `...o(tinycolor.mix(white, hex, 12), "50")` instead of getting overridden by the 'lightest' value.
